### PR TITLE
Clean the bullet navigation part of orbit in foundation.scss

### DIFF
--- a/vendor/assets/stylesheets/foundation.scss
+++ b/vendor/assets/stylesheets/foundation.scss
@@ -830,39 +830,6 @@ div.slider-nav span.left {
 
 .orbit, .orbit-wrapper { width: 100% !important; }
 
-.orbit-bullets {
-    position: absolute;
-    z-index: 1000;
-    list-style: none;
-    bottom: -40px;
-    left: 50%;
-	margin-left: -50px;
-    padding: 0; }
-
-.orbit-bullets li {
-    float: left;
-    margin-left: 5px;
-    cursor: pointer;
-    color: #999;
-    text-indent: -9999px;
-    background: image-url("foundation/orbit/orbit/bullets.jpg") no-repeat 4px 0;
-    width: 13px;
-    height: 12px;
-    overflow: hidden; }
-
-.orbit-bullets li.has-thumb {
-    background: none;
-    width: 100px;
-    height: 75px; }
-
-.orbit-bullets li.active {
-    color: #222;
-    background-position: -8px 0; }
-
-.orbit-bullets li.active.has-thumb {
-    background-position: 0 0;
-    border-top: 2px solid #000; }
-
 /*	--------------------------------------------------
 	Reveal Modals
 	-------------------------------------------------- */


### PR DESCRIPTION
Some duplicate was inserting a bad url for the bullets picture used by orbit.

The duplicate code and the wrong url are deleted. 
