### PR TITLE
Update rails dependency in foundation.gemspec to match README

### DIFF
--- a/foundation.gemspec
+++ b/foundation.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
   # specify any dependencies here; for example:
   # s.add_development_dependency "rspec"
   # s.add_runtime_dependency "rest-client"
-  s.add_runtime_dependency "rails", "~> 3.1.0"
+  s.add_runtime_dependency "rails", "~> 3.1"
   s.add_runtime_dependency "jquery-rails", "~> 1.0"
 end


### PR DESCRIPTION
The README says rails ~> 3.1, which would match any Rails 3.x greater than 3.1. This is required to work with Rails 3.2 (rc1).
