### PR TITLE
Detect application.{extension} when generating assets

### DIFF
--- a/lib/foundation/generators/install_generator.rb
+++ b/lib/foundation/generators/install_generator.rb
@@ -6,19 +6,19 @@ module Foundation
       source_root File.join(File.dirname(__FILE__), 'templates')
       
       def add_assets                  
-        insert_into_file "app/assets/javascripts/application#{detect_js_format}", "//= require foundation\n", :after => "jquery_ujs\n"
-        insert_into_file "app/assets/stylesheets/application#{detect_css_format}", " *= require foundation\n", :after => "require_self\n"              
+        insert_into_file "app/assets/javascripts/application#{detect_js_format[0]}", "#{detect_js_format[1]} require foundation\n", :after => "jquery_ujs\n"
+        insert_into_file "app/assets/stylesheets/application#{detect_css_format[0]}", "#{detect_css_format[1]} require foundation\n", :after => "require_self\n"              
       end
       
       def detect_js_format
-        return '.js.coffee' if File.exist?('app/assets/javascripts/application.js.coffee')
-        return '.js' if File.exist?('app/assets/javascripts/application.js')
+        return ['.js.coffee', '#='] if File.exist?('app/assets/javascripts/application.js.coffee')
+        return ['.js', '//='] if File.exist?('app/assets/javascripts/application.js')
       end
       
       def detect_css_format
-        return '.css' if File.exist?('app/assets/stylesheets/application.css')
-        return '.css.sass' if File.exist?('app/assets/stylesheets/application.css.sass')
-        return '.css.scss' if File.exist?('app/assets/stylesheets/application.css.scss')
+        return ['.css', ' *='] if File.exist?('app/assets/stylesheets/application.css')
+        return ['.css.sass', ' //='] if File.exist?('app/assets/stylesheets/application.css.sass')
+        return ['.css.scss', ' //='] if File.exist?('app/assets/stylesheets/application.css.scss')
       end
     end
   end


### PR DESCRIPTION
The generator was failing to detect the proper file extension for both css and js manifest files. This pull fixes it.
