### PR TITLE
Avoid depend of Rails but railties.

### DIFF
--- a/foundation.gemspec
+++ b/foundation.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
   # specify any dependencies here; for example:
   # s.add_development_dependency "rspec"
   # s.add_runtime_dependency "rest-client"
-  s.add_runtime_dependency "rails", "~> 3.1"
+  s.add_runtime_dependency "railties", ">= 3.2.0", "< 5.0"
   s.add_runtime_dependency "jquery-rails", ">= 1.0"
 end


### PR DESCRIPTION
Avoid depend of Rails but railties. if you depend of rails. you depend o...f 'active_record' and if you don't use it. it's a unnecessary dependencies. Railties is enough.
