### PR TITLE
Tooltips and dymanic content 

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.tooltips.js
+++ b/vendor/assets/javascripts/foundation/jquery.tooltips.js
@@ -10,7 +10,8 @@
   var attributes = {
     bodyHeight : 0,
     pollInterval : 1000
-  };
+  },
+  poll = false;
 
   var methods = {
     init : function( options ) {
@@ -20,13 +21,15 @@
         tips = $('.tooltip'),
         tipTemplate = function(target, content) {
           return '<span data-id="' + target + '" class="tooltip">' + content + '<span class="nub"></span></span>';
-        },
-        poll = setInterval(methods.isDomResized, attributes.pollInterval);
-        if (tips.length < 1) {
-          targets.each(function(i){
-            var target = $(this),
-            id = 'foundationTooltip' + i,
-            content = target.attr('title'),
+        };
+        if (!poll) {
+          poll = setInterval(methods.isDomResized, attributes.pollInterval);
+        }
+        targets.each(function(i){
+          var target = $(this),
+          id = 'foundationTooltip' + i;
+          if (!target.data('id')) {
+            var content = target.attr('title'),
             classes = target.attr('class');
             target.data('id', id);
             var tip = $(tipTemplate(id, content));
@@ -36,8 +39,8 @@
             }
             methods.reposition(target, tip, classes);
             tip.fadeOut(150);
-          });
-        }
+          }
+        });
         $(window).resize(function() {
           var tips = $('.tooltip');
           tips.each(function() {


### PR DESCRIPTION
On the website I work on, we have endless pagination. Tooltips jquery plugin only works once on the first call because of this test

``` javascript
 if (tips.length < 1)
```

So I did few things to be able to call tooltips() more than once
- Remove this test
- Check to run poll timeout only once
- Only generate new tooltips 

I don"t know if there a separated repository for jquery.tooltips.js, didn"t find it :) If yes, let me know I can update send a pull request to the original repository if you want to

Thanks
Seb
