### PR TITLE
Fix FastClick issue, when javascripts placed in head.

### DIFF
--- a/vendor/assets/javascripts/foundation/foundation.js
+++ b/vendor/assets/javascripts/foundation/foundation.js
@@ -36,7 +36,9 @@
 
   // Enable FastClick
   if(typeof FastClick !== 'undefined') {
-    FastClick.attach(document.body);
+    $(document).ready(function() {
+      FastClick.attach(document.body);
+    });
   }
 
   // private Fast Selector wrapper,


### PR DESCRIPTION
Javascripts must be placed in head, when using Rails 4 and Turbolinks. 
So, FastClick initialization simply wrapped as $.ready callback.
