### PR TITLE
Fix sticky_topbar typo

### DIFF
--- a/vendor/assets/javascripts/foundation/foundation.topbar.js
+++ b/vendor/assets/javascripts/foundation/foundation.topbar.js
@@ -35,7 +35,7 @@
         var topbarContainer = topbar.parent();
         if(topbarContainer.hasClass('fixed') || topbarContainer.hasClass(settings.sticky_class)) {
           self.settings.sticky_class = settings.sticky_class;
-          self.settings.stick_topbar = topbar;
+          self.settings.sticky_topbar = topbar;
           topbar.data('height', topbarContainer.outerHeight());
           topbar.data('stickyoffset', topbarContainer.offset().top);
         } else {


### PR DESCRIPTION
This little typo caused the sticky topbar to error out.
