### PR TITLE
Moves the javascript tag into the head for the generated templates.

### DIFF
--- a/lib/foundation/rails/templates/application.html.erb
+++ b/lib/foundation/rails/templates/application.html.erb
@@ -8,12 +8,12 @@
 
     <%%= stylesheet_link_tag    "application" %>
     <%%= javascript_include_tag "vendor/modernizr" %>
+    <%%= javascript_include_tag "application" %>
     <%%= csrf_meta_tags %>
   </head>
 
   <body>
 
     <%%= yield %>
-    <%%= javascript_include_tag "application" %>
   </body>
 </html>

--- a/lib/foundation/rails/templates/application.html.haml
+++ b/lib/foundation/rails/templates/application.html.haml
@@ -2,17 +2,16 @@
 %html{ :lang => "en"}
   %head
     %meta{ :charset => "utf-8" }
-    
+
     %meta{ :name => "viewport", :content => "width=device-width, initial-scale=1.0" }
 
     %title= content_for?(:title) ? yield(:title) : "Untitled"
 
     = stylesheet_link_tag "application"
     = javascript_include_tag "vendor/custom.modernizr"
+    = javascript_include_tag "application"
     = csrf_meta_tag
 
   %body
 
     = yield
-
-    = javascript_include_tag "application"

--- a/lib/foundation/rails/templates/application.html.slim
+++ b/lib/foundation/rails/templates/application.html.slim
@@ -8,10 +8,9 @@ html lang="en"
 
   = stylesheet_link_tag "application"
   = javascript_include_tag "vendor/modernizr"
+  = javascript_include_tag "application"
   = csrf_meta_tag
 
 body
 
   == yield
-
-  = javascript_include_tag "application"


### PR DESCRIPTION
This is necessary to work with rails 4 turbolinks.
