### PR TITLE
Correct path to _settings file.

### DIFF
--- a/lib/foundation/rails/generators/install_generator.rb
+++ b/lib/foundation/rails/generators/install_generator.rb
@@ -15,7 +15,7 @@ module Foundation
           # gsub_file "app/assets/javascripts/application#{detect_js_format[0]}", /\/\/= require jquery\n/, ""
           insert_into_file "app/assets/javascripts/application#{detect_js_format[0]}", "#{detect_js_format[1]} require foundation\n", :after => "jquery_ujs\n"
           append_to_file "app/assets/javascripts/application#{detect_js_format[0]}", "\n$(function(){ $(document).foundation(); });\n"
-          settings_file = File.join(File.dirname(__FILE__),"..", "..", "..", "..","vendor", "_settings.scss")
+          settings_file = File.join(File.dirname(__FILE__),"..", "..", "..", "..", "vendor", "assets", "stylesheets", "foundation", "_settings.scss")
           create_file "app/assets/stylesheets/foundation_and_overrides.scss", File.read(settings_file)
           append_to_file "app/assets/stylesheets/foundation_and_overrides.scss", "\n@import 'foundation';\n"
           insert_into_file "app/assets/stylesheets/application#{detect_css_format[0]}", "\n#{detect_css_format[1]} require foundation_and_overrides\n", :after => "require_self"


### PR DESCRIPTION
I attempted to run `rails generate foundation:install` on a simple rails app, and hit an error:

```
> rails generate foundation:install
      insert  app/assets/javascripts/application.js
      append  app/assets/javascripts/application.js
/Users/brookr/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/foundation-rails-5.0.3.0/lib/foundation/rails/generators/install_generator.rb:19:in `read': No such file or directory @ rb_sysopen - /Users/brookr/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/foundation-rails-5.0.3.0/lib/foundation/rails/generators/../../../../vendor/_settings.scss (Errno::ENOENT)
    from /Users/brookr/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/foundation-rails-5.0.3.0/lib/foundation/rails/generators/install_generator.rb:19:in `add_assets'
    from /Users/brookr/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
    from /Users/brookr/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
    from /Users/brookr/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `block in invoke_all'
    from /Users/brookr/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `each'
    from /Users/brookr/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `map'
    from /Users/brookr/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `invoke_all'
    from /Users/brookr/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/group.rb:233:in `dispatch'
    from /Users/brookr/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
    from /Users/brookr/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/railties-4.0.2/lib/rails/generators.rb:156:in `invoke'
    from /Users/brookr/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/railties-4.0.2/lib/rails/commands/generate.rb:11:in `<top (required)>'
    from /Users/brookr/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/activesupport-4.0.2/lib/active_support/dependencies.rb:229:in `require'
    from /Users/brookr/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/activesupport-4.0.2/lib/active_support/dependencies.rb:229:in `block in require'
    from /Users/brookr/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/activesupport-4.0.2/lib/active_support/dependencies.rb:214:in `load_dependency'
    from /Users/brookr/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/activesupport-4.0.2/lib/active_support/dependencies.rb:229:in `require'
    from /Users/brookr/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/railties-4.0.2/lib/rails/commands.rb:48:in `<top (required)>'
    from bin/rails:4:in `require'
    from bin/rails:4:in `<main>'
```

It seems the `_settings.scss` is actually in a different place than expected. 

This PR presumes the path is incorrect, and the file is in the right place. 

I'd like to submit a test for this as well, but I'm not sure how this repo would like tests organized. Give me some hints, and I'll see what I can do.

Thanks!
