### PR TITLE
Fix _settings.scss filepath

### DIFF
--- a/lib/foundation/rails/generators/install_generator.rb
+++ b/lib/foundation/rails/generators/install_generator.rb
@@ -15,7 +15,7 @@ module Foundation
           # gsub_file "app/assets/javascripts/application#{detect_js_format[0]}", /\/\/= require jquery\n/, ""
           insert_into_file "app/assets/javascripts/application#{detect_js_format[0]}", "#{detect_js_format[1]} require foundation\n", :after => "jquery_ujs\n"
           append_to_file "app/assets/javascripts/application#{detect_js_format[0]}", "\n$(function(){ $(document).foundation(); });\n"
-          settings_file = File.join(File.dirname(__FILE__),"..", "..", "..", "..","vendor", "_settings.scss")
+          settings_file = File.join(File.dirname(__FILE__),"..", "..", "..", "..","vendor", "assets", "stylesheets", "foundation", "_settings.scss")
           create_file "app/assets/stylesheets/foundation_and_overrides.scss", File.read(settings_file)
           append_to_file "app/assets/stylesheets/foundation_and_overrides.scss", "\n@import 'foundation';\n"
           insert_into_file "app/assets/stylesheets/application#{detect_css_format[0]}", "\n#{detect_css_format[1]} require foundation_and_overrides\n", :after => "require_self"


### PR DESCRIPTION
The generator is currently broken under rails 4:

```
rails g foundation:install
```

displays the error

```
gems/foundation-rails-5.0.3.0/lib/foundation/rails/generators/install_generator.rb:19:in `read': No such file or directory - gems/foundation-rails-5.0.3.0/lib/foundation/rails/generators/../../../../vendor/_settings.scss (Errno::ENOENT)
```

This pull request fixes the path that the generator is using.

Why is there no issue tracker for this repository?
