### PR TITLE
removed unused range-slider import

### DIFF
--- a/vendor/assets/stylesheets/foundation.scss
+++ b/vendor/assets/stylesheets/foundation.scss
@@ -25,7 +25,6 @@
   "foundation/components/panels",
   "foundation/components/pricing-tables",
   "foundation/components/progress-bars",
-  "foundation/components/range-slider",
   "foundation/components/reveal",
   "foundation/components/side-nav",
   "foundation/components/split-buttons",


### PR DESCRIPTION
Resolved "File to import not found or unreadable: foundation/components/range-slider" bug
