### PR TITLE
Inline labels higher then input causing row spacing issues

### DIFF
--- a/vendor/assets/stylesheets/foundation/components/_forms.scss
+++ b/vendor/assets/stylesheets/foundation/components/_forms.scss
@@ -158,7 +158,7 @@ $select-bg-color: #fafafa !default;
   }
   @else if $alignment == inline {
     margin: 0 0 $form-spacing 0;
-    padding: $form-spacing / 2 + rem-calc($input-border-width * 2) 0;
+    padding: $form-spacing / 2 0;
   }
 }
 


### PR DESCRIPTION
As the input is using box-sizing: border-box the border is already taken into account in it's size.

This is making the label bigger then it should be and adding extra row margin when it's used.

You can see this issue on your docs http://foundation.zurb.com/docs/components/forms.html#inline-labels the inline label is 36px and the input is 33px

(Tested in Firefox and Chrome, Linux x64)
