### PR TITLE
Fixed problems with nested modals

### DIFF
--- a/vendor/assets/javascripts/foundation/foundation.reveal.js
+++ b/vendor/assets/javascripts/foundation/foundation.reveal.js
@@ -137,7 +137,8 @@
       var self = this;
       if (target) {
         if (typeof target.selector !== 'undefined') {
-          var modal = self.S('#' + target.data(self.data_attr('reveal-id')));
+          // Find the named node; only use the first one found, since the rest of the code assumes there's only one node
+          var modal = self.S('#' + target.data(self.data_attr('reveal-id'))).first();
         } else {
           var modal = self.S(this.scope);
 
@@ -152,14 +153,6 @@
       if (!modal.hasClass('open')) {
         var open_modal = self.S('[' + self.attr_name() + '].open');
 
-        if ( open_modal.length > 0 && !settings ) {
-            // If the open modal was loaded with ajax, and the new modal lives inside it,
-            // it doesn't get initialized properly.  The correct fix is to ensure proper
-            // initialization, but since I'm not clear on how to do that, I'll settle for
-            // getting the settings from the open modal.
-            settings = open_modal.data(self.attr_name(true) + '-init');
-        }
-
         if (typeof modal.data('css-top') === 'undefined') {
           modal.data('css-top', parseInt(modal.css('top'), 10))
             .data('offset', this.cache_offset(modal));
@@ -169,7 +162,7 @@
         modal.trigger('open');
 
         if (open_modal.length < 1) {
-          this.toggle_bg(modal);
+          this.toggle_bg(modal, true);
         }
 
         if (typeof ajax_settings === 'string') {
@@ -195,6 +188,7 @@
 
               modal.html(data);
               self.S(modal).foundation('section', 'reflow');
+              self.S(modal).children().foundation();
 
               if (open_modal.length > 0) {
                 self.hide(open_modal, settings.css.close);
@@ -217,7 +211,7 @@
         this.locked = true;
         this.key_up_off(modal);   // PATCH #3: turning on key up capture only when a reveal window is open
         modal.trigger('close');
-        this.toggle_bg(modal);
+        this.toggle_bg(modal, false);
         this.hide(open_modals, settings.css.close, settings);
       }
     },
@@ -232,18 +226,19 @@
       return base;
     },
 
-    toggle_bg : function (modal) {
-      var settings = modal.data(this.attr_name(true));
-
+    toggle_bg : function (modal, state) {
       if (this.S('.' + this.settings.bg_class).length === 0) {
         this.settings.bg = $('<div />', {'class': this.settings.bg_class})
           .appendTo('body').hide();
       }
 
-      if (this.settings.bg.filter(':visible').length > 0) {
-        this.hide(this.settings.bg);
-      } else {
-        this.show(this.settings.bg);
+      var visible = this.settings.bg.filter(':visible').length > 0;
+      if ( state != visible ) {
+        if ( state == undefined ? visible : !state ) {
+          this.hide(this.settings.bg);
+        } else {
+          this.show(this.settings.bg);
+        }
       }
     },
 


### PR DESCRIPTION
I'm developing a workflow which utilizes "nested", ajax-loaded reveal modals (prior modals are restored in a "closed" handler).  In the process, I encountered and fixed some problems in Foundation Reveal:
1) Elements loaded via ajax didn't get their foundation elements initialized
2) Repeated switching between modals could leave the background out of sync (i.e. visible when no modal was visible)
3) Strange things can happen if page accidentally contains multiple instances of the modal's "mount point"

I made the fixes here because I'm working in Rails.  Please let me know if I should also submit this patch to the master version of Foundation.
