### PR TITLE
Fix Closure compiler error on objPos' trailing comma

### DIFF
--- a/vendor/assets/javascripts/foundation/foundation.tooltip.js
+++ b/vendor/assets/javascripts/foundation/foundation.tooltip.js
@@ -168,7 +168,7 @@
           'top' : (top) ? top : 'auto',
           'bottom' : (bottom) ? bottom : 'auto',
           'left' : (left) ? left : 'auto',
-          'right' : (right) ? right : 'auto',
+          'right' : (right) ? right : 'auto'
         }).end();
       };
 


### PR DESCRIPTION
Forum post: http://foundation.zurb.com/forum/posts/13006

This trailing comma is causing compile errors when using Closure:

```
closure_compiler: ERROR - Parse error. Internet Explorer has a non-standard intepretation of trailing commas. Arrays will have the wrong length and objects will not parse at all.
```

This comma is not present in the 5.2.2 version of Foundation https://github.com/zurb/foundation/blob/master/js/foundation/foundation.tooltip.js 

Removing it allows Closure to successfully compile this file.
