### PR TITLE
Fix Closure compiler error on objPos' trailing comma - 2nd attempt

### DIFF
--- a/vendor/assets/javascripts/foundation/foundation.tooltip.js
+++ b/vendor/assets/javascripts/foundation/foundation.tooltip.js
@@ -168,7 +168,7 @@
           'top' : (top) ? top : 'auto',
           'bottom' : (bottom) ? bottom : 'auto',
           'left' : (left) ? left : 'auto',
-          'right' : (right) ? right : 'auto',
+          'right' : (right) ? right : 'auto'
         }).end();
       };
 


### PR DESCRIPTION
Reopened https://github.com/zurb/foundation-rails/pull/83

@mehlah suggested I file the bug against https://github.com/zurb/foundation

_However_ the problem does not exist in that repository, there is an inconsistency between `zurb/foundation-rails` and `zurb/foundation`.  Note file https://github.com/zurb/foundation/blob/master/js/foundation/foundation.tooltip.js#L171 line 171 does _not_ contain the offending comma.

---

Repost of original pull:

Forum post: http://foundation.zurb.com/forum/posts/13006

This trailing comma is causing compile errors when using Closure:

```
closure_compiler: ERROR - Parse error. Internet Explorer has a non-standard intepretation of trailing commas. Arrays will have the wrong length and objects will not parse at all.
```

This comma is not present in the 5.2.2 version of Foundation https://github.com/zurb/foundation/blob/master/js/foundation/foundation.tooltip.js 

Removing it allows Closure to successfully compile this file.

---

Edit: Link directly to line number
