### PR TITLE
Remove experimental variable and mixin

### DIFF
--- a/vendor/assets/_settings.scss
+++ b/vendor/assets/_settings.scss
@@ -12,8 +12,6 @@
 // Allows the use of rem-calc() or lower-bound() in your settings
 @import "foundation/functions";
 
-// $experimental: true;
-
 // The default font-size is set to 100% of the browser style sheet (usually 16px)
 // for compatibility with browser-based text zoom or user-set defaults.
 

--- a/vendor/assets/stylesheets/foundation/_settings.scss
+++ b/vendor/assets/stylesheets/foundation/_settings.scss
@@ -12,8 +12,6 @@
 // Allows the use of rem-calc() or lower-bound() in your settings
 @import "foundation/functions";
 
-// $experimental: true;
-
 // The default font-size is set to 100% of the browser style sheet (usually 16px)
 // for compatibility with browser-based text zoom or user-set defaults.
 

--- a/vendor/assets/stylesheets/foundation/components/_global.scss
+++ b/vendor/assets/stylesheets/foundation/components/_global.scss
@@ -11,9 +11,6 @@
 // styles get applied to [data-mysite-plugin], etc
 $namespace: false !default;
 
-// Control the inclusion of experimental properties
-$experimental: true !default;
-
 // The default font-size is set to 100% of the browser style sheet (usually 16px)
 // for compatibility with browser-based text zoom or user-set defaults.
 
@@ -28,16 +25,6 @@ $base-line-height: 150% !default;
 //
 // Global Foundation Mixins
 //
-
-// @mixins
-//
-// We use this to optionally include experimental or
-// explicitly vendor prefixed properties
-@mixin experimental() {
-  @if $experimental {
-    @content;
-  }
-}
 
 // @mixins
 //


### PR DESCRIPTION
Duplicating the work done in [this zurb/foundation commit](https://github.com/zurb/foundation/commit/3b3c67d4573ed69f5b8fc0d1ea54e07cf6060a8b). `@experimental` breaks all stylesheets that include both Foundation and Compass. This prevents users of the foundation-rails gem from updating to take advantage of new features or fix bugs that have been addressed.
