### PR TITLE
Fix missing semicolons

### DIFF
--- a/vendor/assets/_settings.scss
+++ b/vendor/assets/_settings.scss
@@ -30,9 +30,9 @@
 // $include-print-styles: true;
 // $include-html-global-classes: $include-html-classes;
 
-// Grid 
+// Grid
 
-// $include-html-block-grid-classes: $include-html-classes; 
+// $include-html-block-grid-classes: $include-html-classes;
 // $include-xl-html-grid-classes: false;
 
 // $row-width: rem-calc(1000);
@@ -41,8 +41,8 @@
 // Global
 
 // We use these to define default font weights
-// $font-weight-normal: normal !default
-// $font-weight-bold: bold !default
+// $font-weight-normal: normal !default;
+// $font-weight-bold: bold !default;
 
 // We use these to control various global styles
 // $body-bg: #fff;

--- a/vendor/assets/stylesheets/foundation/_settings.scss
+++ b/vendor/assets/stylesheets/foundation/_settings.scss
@@ -30,9 +30,9 @@
 // $include-print-styles: true;
 // $include-html-global-classes: $include-html-classes;
 
-// Grid 
+// Grid
 
-// $include-html-block-grid-classes: $include-html-classes; 
+// $include-html-block-grid-classes: $include-html-classes;
 // $include-xl-html-grid-classes: false;
 
 // $row-width: rem-calc(1000);
@@ -41,8 +41,8 @@
 // Global
 
 // We use these to define default font weights
-// $font-weight-normal: normal !default
-// $font-weight-bold: bold !default
+// $font-weight-normal: normal !default;
+// $font-weight-bold: bold !default;
 
 // We use these to control various global styles
 // $body-bg: #fff;


### PR DESCRIPTION
Prevent from that error:

```
Invalid CSS after "...: bold !default": expected selector or at-rule, was "// We use these..."
```
