### PR TITLE
Modified installer in line with README documentation

### DIFF
--- a/lib/foundation/rails/generators/install_generator.rb
+++ b/lib/foundation/rails/generators/install_generator.rb
@@ -14,7 +14,7 @@ module Foundation
           # rails_ujs breaks, need to incorporate rails-behavior plugin for this to work seamlessly
           # gsub_file "app/assets/javascripts/application#{detect_js_format[0]}", /\/\/= require jquery\n/, ""
           insert_into_file "app/assets/javascripts/application#{detect_js_format[0]}", "#{detect_js_format[1]} require foundation\n", :after => "jquery_ujs\n"
-          append_to_file "app/assets/javascripts/application#{detect_js_format[0]}", "\n$(function(){ $(document).foundation(); });\n"
+          append_to_file "app/assets/javascripts/application#{detect_js_format[0]}", "\n$(document).foundation();\n"
           settings_file = File.join(File.dirname(__FILE__),"..", "..", "..", "..", "vendor", "assets", "stylesheets", "foundation", "_settings.scss")
           create_file "app/assets/stylesheets/foundation_and_overrides.scss", File.read(settings_file)
           append_to_file "app/assets/stylesheets/foundation_and_overrides.scss", "\n@import 'foundation';\n"


### PR DESCRIPTION
Manual install instructions in README.md indicate to add `$(document).foundation();` to the `application.js` -- the generator was wrapping this in a function which has been noted as not playing nicely with Turbolinks.
