### PR TITLE
Moving application `javascript_include_tag` to the HTML <head>.

### DIFF
--- a/lib/foundation/rails/templates/application.html.erb
+++ b/lib/foundation/rails/templates/application.html.erb
@@ -8,12 +8,13 @@
 
     <%%= stylesheet_link_tag    "application" %>
     <%%= javascript_include_tag "vendor/modernizr" %>
+    <%%= javascript_include_tag "application" 'data-turbolinks-track' => true %>
     <%%= csrf_meta_tags %>
   </head>
 
   <body>
 
     <%%= yield %>
-    <%%= javascript_include_tag "application" %>
+
   </body>
 </html>

--- a/lib/foundation/rails/templates/application.html.haml
+++ b/lib/foundation/rails/templates/application.html.haml
@@ -9,10 +9,10 @@
 
     = stylesheet_link_tag "application"
     = javascript_include_tag "vendor/modernizr"
+    = javascript_include_tag "application", 'data-turbolinks-track' => true
     = csrf_meta_tag
 
   %body
 
     = yield
 
-    = javascript_include_tag "application"

--- a/lib/foundation/rails/templates/application.html.slim
+++ b/lib/foundation/rails/templates/application.html.slim
@@ -8,10 +8,10 @@ html lang="en"
 
     = stylesheet_link_tag "application"
     = javascript_include_tag "vendor/modernizr"
+    = javascript_include_tag "application", 'data-turbolinks-track' => true
     = csrf_meta_tag
 
   body
 
     == yield
 
-    = javascript_include_tag "application"


### PR DESCRIPTION
Rails 4 now includes Turbolinks by default, therefore adding JavaScript
at the bottom of the <body> element will not play nice with Turbolinks.
The application's JavaScript should be loaded in the HTML <head>.

If a user wants to disable turbolinks, and move the application's
JavaScript files back to the bottom of the HTML <body> element, then
they can do so, but the default templates that gets generated by the
"foundation:install" generator should declare the JavaScript in the
HTML <head>.

Sources:
- https://github.com/rails/turbolinks#evaluating-script-tags
- http://stackoverflow.com/a/20169679/631834
