### PR TITLE
Don't allow sass 3.4+ in the gemspec yet

### DIFF
--- a/foundation-rails.gemspec
+++ b/foundation-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_dependency "sass", [">= 3.2.0"]
+  spec.add_dependency "sass", [">= 3.2.0", "< 3.4"]
   spec.add_dependency "railties", [">= 3.1.0"]
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
This is tied to issues mentioned in:
http://foundation.zurb.com/forum/posts/18856-sass-342-compilation-problem
https://github.com/sass/sass/issues/1397
https://github.com/zurb/foundation/issues/5636
https://github.com/zurb/foundation/pull/5632

Since it seems to be taking time for smarter minds to come up with changes to Foundation 5 that will get it playing nice with sass 3.4, let’s at least modify the dependencies in the meantime so more users like me don’t update their gems and spend forever debugging a very unusual issue.
