### PR TITLE
Update exports to support null index result to prevent break in rails 4.2

### DIFF
--- a/vendor/assets/stylesheets/foundation/_functions.scss
+++ b/vendor/assets/stylesheets/foundation/_functions.scss
@@ -6,11 +6,11 @@
 $rem-base: 16px !default;
 
 // IMPORT ONCE
-// We use this to prevent styles from being loaded multiple times for compenents that rely on other components. 
+// We use this to prevent styles from being loaded multiple times for compenents that rely on other components.
 $modules: () !default;
 @mixin exports($name) {
-  @if (index($modules, $name) == false) {
-    $modules: append($modules, $name);
+  @if (not index($modules, $name)) {
+    $modules: append($modules, $name) !global;
     @content;
   }
 }
@@ -21,7 +21,7 @@ $modules: () !default;
 
 
 // RANGES
-// We use these functions to define ranges for various things, like media queries. 
+// We use these functions to define ranges for various things, like media queries.
 @function lower-bound($range){
   @if length($range) <= 0 {
     @return 0;
@@ -57,23 +57,23 @@ $modules: () !default;
   @return '[data-' + $attr + ']';
 }
 
-// REM CALC 
+// REM CALC
 
 // New Syntax, allows to optionally calculate on a different base value to counter compounding effect of rem's.
 // Call with 1, 2, 3 or 4 parameters, 'px' is not required but supported:
-// 
+//
 //   rem-calc(10 20 30px 40);
-// 
+//
 // Space delimited, if you want to delimit using comma's, wrap it in another pair of brackets
-// 
+//
 //   rem-calc((10, 20, 30, 40px));
-// 
+//
 // Optionally call with a different base (eg: 8px) to calculate rem.
-// 
+//
 //   rem-calc(16px 32px 48px, 8px);
-// 
+//
 // If you require to comma separate your list
-// 
+//
 //   rem-calc((16px, 32px, 48), 8px);
 
 @function rem-calc($values, $base-value: $rem-base) {


### PR DESCRIPTION
Updating to rails 4.2 breaks foundation because of a sass update. The cause of this break can be found at: https://github.com/sass/sass/commit/79bad1ff473cc06c66b85086403f4a1905938e37

The new implementation is based on: https://github.com/wilsonpage/sass-import-once/blob/master/_sass-import-once.scss
