### PR TITLE
Fix reference to ApplicationController that doesn't always exist

### DIFF
--- a/app/controllers/foundation/rails/styleguide_controller.rb
+++ b/app/controllers/foundation/rails/styleguide_controller.rb
@@ -1,6 +1,6 @@
 module Foundation
   module Rails
-    class StyleguideController < ApplicationController
+    class StyleguideController < ::ActionController::Base
       layout false
       def show
         


### PR DESCRIPTION
In situations where foundation-rails is loaded without the rails application (e.g. when sidekiq shares the same Gemfile with an app), and ApplicationController doesn't exist it barfs with an 'uninitialized constant ApplicationController'.

As noted in rails engine guide "The ApplicationController class being inherited from here is the
Blorgh::ApplicationController, not an application's ApplicationController." I think we probably mean to refer to ActionController::Base in this controller. Everything loading correctly now :smiley: 