### PR TITLE
Added coffeescript support for the foundation generator

### DIFF
--- a/lib/foundation/rails/generators/install_generator.rb
+++ b/lib/foundation/rails/generators/install_generator.rb
@@ -14,7 +14,7 @@ module Foundation
           # rails_ujs breaks, need to incorporate rails-behavior plugin for this to work seamlessly
           # gsub_file "app/assets/javascripts/application#{detect_js_format[0]}", /\/\/= require jquery\n/, ""
           insert_into_file "app/assets/javascripts/application#{detect_js_format[0]}", "#{detect_js_format[1]} require foundation\n", :after => "jquery_ujs\n"
-          append_to_file "app/assets/javascripts/application#{detect_js_format[0]}", "\n$(function(){ $(document).foundation(); });\n"
+          append_to_file "app/assets/javascripts/application#{detect_js_format[0]}", "#{detect_js_format[2]}"
           settings_file = File.join(File.dirname(__FILE__),"..", "..", "..", "..", "vendor", "assets", "stylesheets", "foundation", "_settings.scss")
           create_file "app/assets/stylesheets/foundation_and_overrides.scss", File.read(settings_file)
           append_to_file "app/assets/stylesheets/foundation_and_overrides.scss", "\n@import 'foundation';\n"
@@ -22,9 +22,9 @@ module Foundation
         end
 
         def detect_js_format
-          return ['.coffee', '#='] if File.exist?('app/assets/javascripts/application.coffee')
-          return ['.js.coffee', '#='] if File.exist?('app/assets/javascripts/application.js.coffee')
-          return ['.js', '//='] if File.exist?('app/assets/javascripts/application.js')
+          return ['.coffee', '#=', "\n() ->\n  $(document).foundation()\n"] if File.exist?('app/assets/javascripts/application.coffee')
+          return ['.js.coffee', '#=', "\n() ->\n  $(document).foundation()\n"] if File.exist?('app/assets/javascripts/application.js.coffee')
+          return ['.js', '//=', "\n$(function(){ $(document).foundation(); });\n"] if File.exist?('app/assets/javascripts/application.js')
         end
 
         def detect_css_format


### PR DESCRIPTION
When I run the generator on Rails with Coffee files, the generated text appended to the `application.coffee` file is

``` javascript
$(document).foundation();
```

whereas the expected text is

``` coffeescript
() ->
  $(document).foundation()
```

Have attached a patch for the same.
