### PR TITLE
Update sass dependency to >= 3.3.0, < 3.5

### DIFF
--- a/foundation-rails.gemspec
+++ b/foundation-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_dependency "sass", [">= 3.2.0", "< 3.4"]
+  spec.add_dependency "sass", [">= 3.3.0", "< 3.5"]
   spec.add_dependency "railties", [">= 3.1.0"]
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
According to the [Foundation changelog][1], version 5.5 is now compatible with Sass 3.4, while 3.2 compatibility has been removed. If that is the case, then presumably this gem should also change its dependencies to reflect that.

I know there was some jumping back and forth with the supported Sass versions during Foundation 5.4, so it would be appreciated if someone from @zurb could confirm that the current working versions are indeed **3.3** and **3.4**. :)

  [1]: http://foundation.zurb.com/docs/changelog.html#5-5-december-12th-2014