### PR TITLE
allow newer sass versions again than 3.3.x

### DIFF
--- a/foundation-rails.gemspec
+++ b/foundation-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_dependency "sass", [">= 3.2.0", "< 3.4"]
+  spec.add_dependency "sass", ["~> 3.2"]
   spec.add_dependency "railties", [">= 3.1.0"]
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
as constraint makes https://github.com/zurb/foundation-rails/commit/af76360438507704c66928e4b1d4e711139a8991 useless and issues mentioned in commit https://github.com/zurb/foundation-rails/commit/8bccbe2ca3d772669e08e4d3b86517efdcfa89c8 have been resolved