### PR TITLE
Import the global variables in the toolbar styles

### DIFF
--- a/vendor/assets/stylesheets/foundation/components/_toolbar.scss
+++ b/vendor/assets/stylesheets/foundation/components/_toolbar.scss
@@ -3,6 +3,8 @@
 // Licensed under MIT Open Source
 // toolbar styles
 
+@import "global";
+
 .toolbar {
 	background: $oil;
 	width: 100%;


### PR DESCRIPTION
When trying to precompile Foundation, the toolbar component produces an error for undefined color variables. Importing the global variables in that file solves the problem and allows Foundation to precompile successfully.