### PR TITLE
Require 'foundation' before the rest of the JS files

### DIFF
--- a/vendor/assets/javascripts/foundation.js
+++ b/vendor/assets/javascripts/foundation.js
@@ -1,3 +1,4 @@
+//= require foundation/foundation
 //= require foundation/foundation.abide
 //= require foundation/foundation.accordion
 //= require foundation/foundation.alert
@@ -6,7 +7,6 @@
 //= require foundation/foundation.equalizer
 //= require foundation/foundation.interchange
 //= require foundation/foundation.joyride
-//= require foundation/foundation
 //= require foundation/foundation.magellan
 //= require foundation/foundation.offcanvas
 //= require foundation/foundation.orbit


### PR DESCRIPTION
Trying to require other JS files before "foundation" results in JS errors when those files try to reference "Foundation".