### PR TITLE
Fix for foundation cannot be found when using Heroku 

### DIFF
--- a/lib/foundation/rails/generators/install_generator.rb
+++ b/lib/foundation/rails/generators/install_generator.rb
@@ -13,7 +13,8 @@ module Foundation
         def add_assets
           # rails_ujs breaks, need to incorporate rails-behavior plugin for this to work seamlessly
           # gsub_file "app/assets/javascripts/application#{detect_js_format[0]}", /\/\/= require jquery\n/, ""
-          insert_into_file "app/assets/javascripts/application#{detect_js_format[0]}", "#{detect_js_format[1]} require foundation\n require foundation/foundation\n", :after => "jquery_ujs\n"
+          insert_into_file "app/assets/javascripts/application#{detect_js_format[0]}", "#{detect_js_format[1]} require foundation\n", :after => "jquery_ujs\n"
+          insert_into_file "app/assets/javascripts/application#{detect_js_format[0]}", "#{detect_js_format[1]} require foundation/foundation\n", :after => "jquery_ujs\n"
           append_to_file "app/assets/javascripts/application#{detect_js_format[0]}", "#{detect_js_format[2]}"
           settings_file = File.join(File.dirname(__FILE__),"..", "..", "..", "..", "vendor", "assets", "stylesheets", "foundation", "_settings.scss")
           create_file "app/assets/stylesheets/foundation_and_overrides.scss", File.read(settings_file)

--- a/lib/foundation/rails/generators/install_generator.rb
+++ b/lib/foundation/rails/generators/install_generator.rb
@@ -13,7 +13,7 @@ module Foundation
         def add_assets
           # rails_ujs breaks, need to incorporate rails-behavior plugin for this to work seamlessly
           # gsub_file "app/assets/javascripts/application#{detect_js_format[0]}", /\/\/= require jquery\n/, ""
-          insert_into_file "app/assets/javascripts/application#{detect_js_format[0]}", "#{detect_js_format[1]} require foundation\n", :after => "jquery_ujs\n"
+          insert_into_file "app/assets/javascripts/application#{detect_js_format[0]}", "#{detect_js_format[1]} require foundation\n require foundation/foundation\n", :after => "jquery_ujs\n"
           append_to_file "app/assets/javascripts/application#{detect_js_format[0]}", "#{detect_js_format[2]}"
           settings_file = File.join(File.dirname(__FILE__),"..", "..", "..", "..", "vendor", "assets", "stylesheets", "foundation", "_settings.scss")
           create_file "app/assets/stylesheets/foundation_and_overrides.scss", File.read(settings_file)


### PR DESCRIPTION
The default generator works fine under localhost:3000 but when assets are compiled and pushed to Heroku, foundation cannot be found and fails to load. By adding foundation/foundation to application.js as part of the generator everything works as expected. 

Demo apps: 

Unpatched:
https://enigmatic-river-5597.herokuapp.com/

Patched:
https://safe-tor-8054.herokuapp.com/