### PR TITLE
Correct JavaScript files require order.

### DIFF
--- a/vendor/assets/javascripts/foundation.js
+++ b/vendor/assets/javascripts/foundation.js
@@ -1,3 +1,4 @@
+//= require foundation/foundation
 //= require foundation/foundation.abide
 //= require foundation/foundation.accordion
 //= require foundation/foundation.alert
@@ -6,7 +7,6 @@
 //= require foundation/foundation.equalizer
 //= require foundation/foundation.interchange
 //= require foundation/foundation.joyride
-//= require foundation/foundation
 //= require foundation/foundation.magellan
 //= require foundation/foundation.offcanvas
 //= require foundation/foundation.orbit


### PR DESCRIPTION
I'm getting JavaScript errors in my console for all the files required above the one moved. Requiring `foundation/foundation` at the top seems to fix this issue.