### PR TITLE
Use correct active link color in side_nav mixin

### DIFF
--- a/vendor/assets/stylesheets/foundation/components/_side-nav.scss
+++ b/vendor/assets/stylesheets/foundation/components/_side-nav.scss
@@ -89,7 +89,7 @@ $side-nav-divider-color: scale-color($white, $lightness: -10%) !default;
     }
 
     &.active > a:first-child:not(.button) {
-      color: $side-nav-link-color-active;
+      color: $link-color-active;
       font-family: $side-nav-font-family-active;
       font-weight: $side-nav-font-weight-active;
     }


### PR DESCRIPTION
The side_nav mixin takes link-color-active as a parameter, but it is not used properly (the global side-nav-link-color-active is used instead, when it is supposed to just be a default).

This patch fixes it. I haven't checked if this is fixed upstream or not.