### PR TITLE
Version up to 5.5.3.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "foundation-rails",
-  "version": "5.5.3.1",
+  "version": "5.5.3.2",
   "dependencies": {
     "foundation": "5.5.3"
   }

--- a/lib/foundation/rails/version.rb
+++ b/lib/foundation/rails/version.rb
@@ -1,5 +1,5 @@
 module Foundation
   module Rails
-    VERSION = "5.5.3.1"
+    VERSION = "5.5.3.2"
   end
 end


### PR DESCRIPTION
Last version (5.5.3.1) broke backwards compatibility introducing the require order error that has been fixed with the merge of the PR #126. Please consider releasing a new version 5.5.3.2 as soon as posible.