### PR TITLE
Require order (bug previously fixed reintroduced in 5.5.3)

### DIFF
--- a/vendor/assets/javascripts/foundation.js
+++ b/vendor/assets/javascripts/foundation.js
@@ -1,3 +1,4 @@
+//= require foundation/foundation
 //= require foundation/foundation.abide
 //= require foundation/foundation.accordion
 //= require foundation/foundation.alert
@@ -6,7 +7,6 @@
 //= require foundation/foundation.equalizer
 //= require foundation/foundation.interchange
 //= require foundation/foundation.joyride
-//= require foundation/foundation
 //= require foundation/foundation.magellan
 //= require foundation/foundation.offcanvas
 //= require foundation/foundation.orbit


### PR DESCRIPTION
As said in #129, the `require` order in 5.5.3 is incorrect and it reintroduced a bug fixed by #117.