### PR TITLE
Rakefile task for vendoring Foundation 6

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,5 @@ RSpec::Core::RakeTask.new(:rspec)
 
 desc 'Run the test suite'
 task :default => :rspec
+
+import 'tasks/import.rake'

--- a/tasks/import.rake
+++ b/tasks/import.rake
@@ -1,0 +1,38 @@
+require 'fileutils'
+
+desc 'Copy the files from a Foundation 6 distribution to vendor/'
+task :import6 do
+  base = ENV['DIR']
+  unless base && File.exist?(base)
+    puts 'Could not find Foundation distribution directory'
+    exit 1
+  end
+
+  FileUtils.rm_r 'vendor'
+  FileUtils.mkdir_p 'vendor/assets/javascripts/foundation'
+  FileUtils.mkdir_p 'vendor/assets/stylesheets'
+
+  js_files = []
+  [
+    'foundation.core.js',
+    'foundation.util.*.js',
+    'foundation.*.js',
+  ].each do |pattern|
+    js_files += Dir.glob(File.join(base, 'js', pattern)).map do |path|
+      File.basename path
+    end
+  end
+  js_files.uniq!
+
+  File.open 'vendor/assets/javascripts/foundation.js', 'wb' do |f|
+    js_files.each do |file|
+      f.write "//= require foundation/#{file}\n"
+      FileUtils.cp File.join(base, 'js', file),
+                   'vendor/assets/javascripts/foundation'
+    end
+  end
+
+  FileUtils.cp_r File.join(base, 'scss'), 'vendor/assets/stylesheets/'
+  FileUtils.mv 'vendor/assets/stylesheets/scss',
+               'vendor/assets/stylesheets/foundation'
+end


### PR DESCRIPTION
I'm posting this PR for folks who'd like to use Foundation 6 RC in their Rails applications before its the final release. Here's how it can be used.

```bash
git checkout rake6
git branch -D f6  # Get rid of a previously created f6 branch.
git checkout https://github.com/zurb/foundation-sites-6.git ~/workspace/foundation-sites-6
rake import6 DIR=~/workspace/foundation-sites-6
git checkout master
git checkout -b f6
git add vendor/
git commit -m "Vendor Foundation for Sites 6."
git push -u -f origin f6
```

Reference the branch in the `Gemfile`.

```ruby
gem 'foundation-rails', git: 'https://github.com/pwnall/foundation-rails.git',
    branch: 'f6'
```

After updating the vendored Foundation for Sites, update the commit hash in `Gemfile.lock`.

```bash
bundle update foundation-rails
```

I hope this helps!