### PR TITLE
Require "core" first since it's needed by other modules

### DIFF
--- a/vendor/assets/js/foundation.js
+++ b/vendor/assets/js/foundation.js
@@ -1,7 +1,7 @@
+//= require foundation.core
 //= require foundation.abide
 //= require foundation.accordion
 //= require foundation.accordionMenu
-//= require foundation.core
 //= require foundation.drilldown
 //= require foundation.dropdown
 //= require foundation.dropdownMenu


### PR DESCRIPTION
Hello,

First, thanks a lot for Foundation 6 and for updating this gem!

There is an error in the order files are required here : https://github.com/zurb/foundation-rails/blob/master/vendor/assets/js/foundation.js

This causes an error for `abide`, `accordion` and `accordionMenu` which are required before `core`.

It has been fixed by @kball here : https://github.com/zurb/foundation-rails/commit/086e336349d92f66751c6e91992cfec9ec8393fa
But then changed again here : https://github.com/zurb/foundation-rails/commit/80388ff18e8ed1f6fb28d860b8abb46332e87a3a

Thanks!