### PR TITLE
Generator Refactor

### DIFF
--- a/lib/foundation/rails/engine.rb
+++ b/lib/foundation/rails/engine.rb
@@ -1,3 +1,5 @@
+require 'rails'
+
 module Foundation
   module Rails
     class Engine < ::Rails::Engine

--- a/lib/foundation/rails/engine.rb
+++ b/lib/foundation/rails/engine.rb
@@ -2,9 +2,6 @@ module Foundation
   module Rails
     class Engine < ::Rails::Engine
       isolate_namespace Foundation::Rails
-      initializer "foundation-rails.assets.precompile" do |app|
-        app.config.assets.precompile += %w( vendor/modernizr.js )
-      end
     end
   end
 end

--- a/lib/generators/foundation/install_generator.rb
+++ b/lib/generators/foundation/install_generator.rb
@@ -19,26 +19,33 @@ module Foundation
       end
 
       def detect_js_format
-        return ['.coffee', '#=', "\n() ->\n  $(document).foundation()\n"] if File.exist?(File.join(javascripts_base_dir, 'application.coffee'))
-        return ['.coffee.erb', '#=', "\n() ->\n  $(document).foundation()\n"] if File.exist?(File.join(javascripts_base_dir, 'application.coffee.erb'))
-        return ['.js.coffee', '#=', "\n() ->\n  $(document).foundation()\n"] if File.exist?(File.join(javascripts_base_dir, 'application.js.coffee'))
-        return ['.js.coffee.erb', '#=', "\n() ->\n  $(document).foundation()\n"] if File.exist?(File.join(javascripts_base_dir, 'application.js.coffee.erb'))
-        return ['.js', '//=', "\n$(function(){ $(document).foundation(); });\n"] if File.exist?(File.join(javascripts_base_dir, 'application.js'))
-        return ['.js.erb', '//=', "\n$(function(){ $(document).foundation(); });\n"] if File.exist?(File.join(javascripts_base_dir, 'application.js.erb'))
+        %w(.coffee .coffee.erb .js.coffee .js.coffee.erb .js .js.erb).each do |ext|
+          if File.exist?(File.join(javascripts_base_dir, "application#{ext}"))
+            if ext.include?(".coffee")
+              return [ext, "#=", "\n() ->\n  $(document).foundation()\n"]
+            else
+              return [ext, "//=", "\n$(function(){ $(document).foundation(); });\n"]
+            end
+          end
+        end
       end
 
       def detect_css_format
-        return ['.css', ' *='] if File.exist?(File.join(stylesheets_base_dir, 'application.css'))
-        return ['.css.sass', ' //='] if File.exist?(File.join(stylesheets_base_dir, 'application.css.sass'))
-        return ['.sass', ' //='] if File.exist?(File.join(stylesheets_base_dir, 'application.sass'))
-        return ['.css.scss', ' //='] if File.exist?(File.join(stylesheets_base_dir, 'application.css.scss'))
-        return ['.scss', ' //='] if File.exist?(File.join(stylesheets_base_dir, 'application.scss'))
+        %w(.css .css.sass .sass .css.scss .scss).each do |ext|
+          if File.exist?(File.join(stylesheets_base_dir, "application#{ext}"))
+            if ext.include?(".sass") || ext.include?(".scss")
+              return [ext, "//="]
+            else
+              return [ext, " *="]
+            end
+          end
+        end
       end
 
       def create_layout
-        if options.haml?||(defined?(Haml) && options.haml?)
+        if options.haml? || (defined?(Haml) && options.haml?)
           template 'application.html.haml', File.join(layouts_base_dir, "#{file_name}.html.haml")
-        elsif options.slim?||(defined?(Slim) && options.slim?)
+        elsif options.slim? || (defined?(Slim) && options.slim?)
           template 'application.html.slim', File.join(layouts_base_dir, "#{file_name}.html.slim")
         else
           template 'application.html.erb', File.join(layouts_base_dir, "#{file_name}.html.erb")

--- a/lib/generators/foundation/templates/application.html.erb
+++ b/lib/generators/foundation/templates/application.html.erb
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <title><%%= content_for?(:title) ? yield(:title) : "foundation-rails" %></title>
+    <title><%%= content_for?(:title) ? yield(:title) : "Untitled" %></title>
 
     <%%= stylesheet_link_tag    "application" %>
     <%%= javascript_include_tag "application", 'data-turbolinks-track' => true %>

--- a/lib/generators/foundation/templates/application.html.haml
+++ b/lib/generators/foundation/templates/application.html.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html{ :lang => "en"}
+%html{ :lang => "en" }
   %head
     %meta{ :charset => "utf-8" }
 
@@ -8,7 +8,7 @@
     %title= content_for?(:title) ? yield(:title) : "Untitled"
 
     = stylesheet_link_tag "application"
-    = javascript_include_tag "application", 'data-turbolinks-track' => true
+    = javascript_include_tag "application", "data-turbolinks-track" => true
     = csrf_meta_tag
 
   %body

--- a/lib/generators/foundation/templates/application.html.slim
+++ b/lib/generators/foundation/templates/application.html.slim
@@ -7,7 +7,7 @@ html lang="en"
     title == content_for?(:title) ? yield(:title) : "Untitled"
 
     = stylesheet_link_tag "application"
-    = javascript_include_tag "application", 'data-turbolinks-track' => true
+    = javascript_include_tag "application", "data-turbolinks-track" => true
     = csrf_meta_tag
 
   body

--- a/spec/features/generator_spec.rb
+++ b/spec/features/generator_spec.rb
@@ -19,7 +19,6 @@ feature 'Foundation install succeeds' do
     layout_file = IO.read("#{dummy_app_path}/app/views/layouts/application.html.erb")
 
     expect(layout_file).to match(/stylesheet_link_tag    "application"/)
-    expect(layout_file).to match(/javascript_include_tag "vendor\/modernizr"/)
     expect(layout_file).to match(/javascript_include_tag "application/)
   end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -7,7 +7,7 @@ module FoundationRailsTestHelpers
       end
     end
     FileUtils.cd(dummy_app_path) do
-      %(bundle install)
+      %x(bundle install)
     end
   end
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -3,7 +3,7 @@ module FoundationRailsTestHelpers
     FileUtils.cd(tmp_path) do
       %x(rails new dummy --skip-active-record --skip-test-unit --skip-spring --skip-bundle)
       File.open(dummy_app_path + '/Gemfile', 'a') do |f|
-        puts "gem 'foundation-rails', path: #{File.dirname(__FILE__)}"
+        f.puts "gem 'foundation-rails', path: #{File.dirname(__FILE__)}"
       end
     end
     FileUtils.cd(dummy_app_path) do

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,7 +1,13 @@
 module FoundationRailsTestHelpers
   def create_dummy_app
     FileUtils.cd(tmp_path) do
-      %x(rails new dummy --skip-active-record --skip-test-unit --skip-spring)
+      %x(rails new dummy --skip-active-record --skip-test-unit --skip-spring --skip-bundle)
+      File.open(dummy_app_path + '/Gemfile', 'a') do |f|
+        puts "gem 'foundation-rails', path: #{File.dirname(__FILE__)}"
+      end
+    end
+    FileUtils.cd(dummy_app_path) do
+      %(bundle install)
     end
   end
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -3,7 +3,7 @@ module FoundationRailsTestHelpers
     FileUtils.cd(tmp_path) do
       %x(rails new dummy --skip-active-record --skip-test-unit --skip-spring --skip-bundle)
       File.open(dummy_app_path + '/Gemfile', 'a') do |f|
-        f.puts "gem 'foundation-rails', path: #{File.dirname(__FILE__)}"
+        f.puts "gem 'foundation-rails', path: '#{File.join(File.dirname(__FILE__), '..', '..')}'"
       end
     end
     FileUtils.cd(dummy_app_path) do


### PR DESCRIPTION
This PR addresses the following:

- Refactoring of the Foundation generator to cut down on some repetition in the format detection methods
- Removal of references to modernizr, since F6 no longer uses it as a dependency
- Updates to tests and test helpers
- Addition of a missing require statement for Rails - this was causing an issue with running RSpec tests locally