### PR TITLE
Mention initial copyright year

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2016 ZURB Inc.
+Copyright (c) 2013-2016 ZURB Inc.
 
 MIT License
 


### PR DESCRIPTION
I am not a lawyer but according to http://www.copyright.gov/circs/circ01.pdf (See screenshot of relevant section below), mentioning the first year of publication in the copyright is a good thing

![selection_008](https://cloud.githubusercontent.com/assets/829526/12409934/7021c3a6-be95-11e5-8d1a-18f6948571e0.png)

Also introduced range in the license till the latest release (which happened in `2016`)