### PR TITLE
Update assets:update Rake task to update _settings.scss to the latest version available + _settings.scss presence test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,7 @@ namespace :assets do
     sh 'bower install'
     sh 'cp -R bower_components/foundation-sites/js/* vendor/assets/js/'
     sh 'cp -R bower_components/foundation-sites/scss/* vendor/assets/scss/'
+    sh 'cp -R bower_components/foundation-sites/scss/settings/_settings.scss lib/generators/foundation/templates'
     sh 'cp -R bower_components/motion-ui/src/* vendor/assets/scss/motion-ui'
 
     js_files = Dir['vendor/assets/js/*.js'].sort

--- a/spec/features/generator_spec.rb
+++ b/spec/features/generator_spec.rb
@@ -4,6 +4,7 @@ feature 'Foundation install succeeds' do
   scenario 'stylesheets assets files are added' do
     application_css_file = IO.read("#{dummy_app_path}/app/assets/stylesheets/application.css")
 
+    expect(File).to exist("#{dummy_app_path}/app/assets/stylesheets/_settings.scss")
     expect(File).to exist("#{dummy_app_path}/app/assets/stylesheets/foundation_and_overrides.scss")
     expect(application_css_file).to match(/require foundation_and_overrides/)
   end


### PR DESCRIPTION
In the `6.2.0.0` release of the gem, the [`_settings.scss`](https://github.com/zurb/foundation-rails/blob/master/lib/generators/foundation/templates/_settings.scss) file is outdated.

I updated the `assets:update` Rake task to also update `_settings.scss` to the latest version.

I also updated a test to check if `_settings.scss` is where it should be.