### PR TITLE
Fixes the missing menu-icon

### DIFF
--- a/lib/generators/foundation/templates/foundation_and_overrides.scss
+++ b/lib/generators/foundation/templates/foundation_and_overrides.scss
@@ -30,6 +30,7 @@
 @include foundation-label;
 @include foundation-media-object;
 @include foundation-menu;
+@include foundation-menu-icon;
 @include foundation-off-canvas;
 @include foundation-orbit;
 @include foundation-pagination;


### PR DESCRIPTION
The generator missed the menu-icon include after the version bump to
6.2.0. This PR adds the menu-icon to the foundation_and_overrides.scss.

The `_menu-icon.scss` was added in this commit:
https://github.com/stefanvermaas/foundation-rails/blob/c0ee2a1a85c36f4089a2e8a6ca25c93c1357141d/vendor/assets/scss/components/_menu-icon.scss

Cheers!