### PR TITLE
Include the foundation-menu-icon in the default templte.

### DIFF
--- a/lib/generators/foundation/templates/foundation_and_overrides.scss
+++ b/lib/generators/foundation/templates/foundation_and_overrides.scss
@@ -30,6 +30,7 @@
 @include foundation-label;
 @include foundation-media-object;
 @include foundation-menu;
+@include foundation-menu-icon;
 @include foundation-off-canvas;
 @include foundation-orbit;
 @include foundation-pagination;


### PR DESCRIPTION
Fixes https://github.com/zurb/foundation-rails/issues/172. I believe this was simply missing from the template.

@panigrah