### PR TITLE
Fixes HTML validation errors

### DIFF
--- a/vendor/assets/javascripts/foundation/foundation.js
+++ b/vendor/assets/javascripts/foundation/foundation.js
@@ -13,7 +13,7 @@
     var head = $('head');
     head.prepend($.map(class_array, function (class_name) {
       if (head.has('.' + class_name).length === 0) {
-        return '<meta class="' + class_name + '" />';
+        return '<meta content="' + class_name + '" name="' + class_name + '" class="' + class_name + '" />';
       }
     }));
   };
@@ -579,7 +579,7 @@
       //    Class (String): Class name for the generated <meta> tag
       register_media : function (media, media_class) {
         if (Foundation.media_queries[media] === undefined) {
-          $('head').append('<meta class="' + media_class + '"/>');
+          $('head').append('<meta content="' + media_class + '" name="' + media_class + '" class="' + media_class + '"/>');
           Foundation.media_queries[media] = removeQuotes($('.' + media_class).css('font-family'));
         }
       },


### PR DESCRIPTION
* Fixes the following HTML validation errors in the generated meta tags:

  Error: Element meta is missing one or more of the following attributes: charset, content, http-equiv, itemprop, name, property.

```
  <meta class="foundation-data-attribute-namespace">
  <meta class="foundation-mq-xxlarge">
  <meta class="foundation-mq-xlarge">
  <meta class="foundation-mq-large">
  <meta class="foundation-mq-medium">
  <meta class="foundation-mq-small">
  <meta class="foundation-mq-topbar">
```

http://w3c.github.io/html/single-page.html#the-meta-element

![screen shot 2016-03-23 at 20 26 17](https://cloud.githubusercontent.com/assets/547777/14007555/709dabd0-f13d-11e5-8d82-282e5af9ff73.png)

Thanks to @mvandenbeuken for pairing on this one