### PR TITLE
Remove "$" from gem command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Add this line to your application's Gemfile:
 
-    $ gem 'foundation-rails'
+    gem 'foundation-rails'
 
 And then execute:
 


### PR DESCRIPTION
Removed $ command from installation instructions. Since "$" represents bash, it looks like a bash command which makes it a bit confusing.