### PR TITLE
Fix of the installation guide with SCSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Append the following line to your `app/assets/stylesheets/application.css` file:
 
 If you're planning on using Sass, then you'll want to rename `application.css` to `application.scss`. That file should then look like:
 
-    @import "foundation_and_overrides";
+    @import "foundation";
+    @include foundation-everything();
     /* Add imports of custom sass/scss files here */
 
 ### Add Foundation to your JS


### PR DESCRIPTION
Hello,

It seems like the README is outdated. `foundation_and_overrides` doesn't exists anymore.

Therefore, the generator should not works also (I didn't tested this part).