### PR TITLE
Comments out logging of focus in Reveal.

### DIFF
--- a/vendor/assets/js/foundation.reveal.js.es6
+++ b/vendor/assets/js/foundation.reveal.js.es6
@@ -238,7 +238,7 @@ class Reveal {
             'tabindex': -1
           })
           .focus();
-          console.log('focus');
+          //console.log('focus');
       }
       if (this.options.overlay) {
         Foundation.Motion.animateIn(this.$overlay, 'fade-in');


### PR DESCRIPTION
I'm getting a ton of "focus" messages outputted during capybara testing. This should take care of that.