### PR TITLE
Update foundation.js

### DIFF
--- a/vendor/assets/javascripts/foundation.js
+++ b/vendor/assets/javascripts/foundation.js
@@ -1,3 +1,4 @@
+//= require foundation/foundation
 //= require foundation/foundation.abide
 //= require foundation/foundation.accordion
 //= require foundation/foundation.alert
@@ -6,7 +7,6 @@
 //= require foundation/foundation.equalizer
 //= require foundation/foundation.interchange
 //= require foundation/foundation.joyride
-//= require foundation/foundation
 //= require foundation/foundation.magellan
 //= require foundation/foundation.offcanvas
 //= require foundation/foundation.orbit


### PR DESCRIPTION
This is the result of running `rake assets:update`. It restores the correct asset order.

You should also update the v5.3.3.2 tag or create a new tag.