### PR TITLE
Fix smoothScroll reference in foundation.js

### DIFF
--- a/vendor/assets/js/foundation.js
+++ b/vendor/assets/js/foundation.js
@@ -9,6 +9,7 @@
 //= require foundation.util.timerAndImageLoader.js
 //= require foundation.util.touch.js
 //= require foundation.util.triggers.js
+//= require foundation.smoothScroll.js
 //= require foundation.abide.js
 //= require foundation.accordion.js
 //= require foundation.accordionMenu.js
@@ -25,7 +26,6 @@
 //= require foundation.responsiveToggle.js
 //= require foundation.reveal.js
 //= require foundation.slider.js
-//= require foundation.smoothScroll.js
 //= require foundation.sticky.js
 //= require foundation.tabs.js
 //= require foundation.toggler.js


### PR DESCRIPTION
This is a fix for the issue I posted in #235. Magellan seems to reference smoothScroll, which causes issues in development on rails `5.1.2`, since it's being included after magellan.js in the foundation.js manifest.