### PR TITLE
Fix issues with size restricted unstack, collapse, and uncollapse (6.4.0+)

### DIFF
--- a/vendor/assets/scss/util/_breakpoint.scss
+++ b/vendor/assets/scss/util/_breakpoint.scss
@@ -146,6 +146,13 @@ $breakpoint-classes: (small medium large) !default;
 
   // Make breakpoint size available as a variable
   $old-zf-size: $-zf-zero-breakpoint;
+  
+  // Store the existing -zf-size variable so that calls to -zf-each-breakpoint
+  // will not break when loop contains a call to breakpoint
+  @if variable_exists(-zf-size) {
+    $old-zf-size: $-zf-size;
+  }
+  
   $-zf-size: nth($value, 1) !global; // get the first value to account for `only` and `down` keywords
 
   // If $str is still an empty string, no media query is needed


### PR DESCRIPTION
For versions 6.4.0 and higher, size-restricted calls to unstack, collapse, and uncollapse, would not work because the first breakpoint for each of those was being set multiple times. As such, the generated CSS would include several` .small-uncollapse` declarations, but nothing for the larger sizes.

The problem stems from a [this commit of _breakpoint.scss](https://github.com/zurb/foundation-rails/commit/2be28a55edb27f9e077b4a69358c96f97fa01dcf#diff-9c6bed6e1340462ef2def9f07684d858R147) which would overwrite the currently set `-zf-size` variable and replace it with `-zf-zero-breakpoint`.

This is an issue for the _flex-grid.scss declarations included in the loop beginning at line 193 because everything after the call to` @include breakpoint` on line 218 would be completed with the first breakpoint instead of the intended one.  

This change checks to see if the `-zf-size` variable is already set and stores that instead of the `-zf-zero-breakpoint`.