### PR TITLE
[CLEANUP] Remove Sass deprecation warning

### DIFF
--- a/vendor/assets/scss/xy-grid/_gutters.scss
+++ b/vendor/assets/scss/xy-grid/_gutters.scss
@@ -30,7 +30,7 @@
 
       // Loop through each gutter position
       @each $value in $gutter-position {
-        #{$gutter-type}-#{$value}: #{$operator}$gutter;
+        #{$gutter-type}-#{$value}: unquote("#{$operator}#{$gutter}");
       }
     }
   }
@@ -39,7 +39,7 @@
 
     // Loop through each gutter position
     @each $value in $gutter-position {
-      #{$gutter-type}-#{$value}: #{$operator}$gutter;
+      #{$gutter-type}-#{$value}: unquote("#{$operator}#{$gutter}");
     }
   }
 }


### PR DESCRIPTION
DEPRECATION WARNING: #{} interpolation near operators will be simplified in a future version
of Sass.

Source:
https://github.com/zurb/foundation-sites/blob/eaa79c89a8c5dc89f8fa1e6916ce5dea6cc55866/scss/xy-grid/_gutters.scss#L33

This closes #246