### PR TITLE
Change import order in template

### DIFF
--- a/lib/generators/foundation/templates/foundation_and_overrides.scss
+++ b/lib/generators/foundation/templates/foundation_and_overrides.scss
@@ -1,7 +1,7 @@
 @charset 'utf-8';
 
-@import 'settings';
 @import 'foundation';
+@import 'settings';
 
 // If you'd like to include motion-ui the foundation-rails gem comes prepackaged with it, uncomment the 3 @imports, if you are not using the gem you need to install the motion-ui sass package.
 //


### PR DESCRIPTION
When executing the `rails g foundation: install` command ` foundation_and_overrides.scss` template imports the settings before importing Foundation. This way the last version of Rails show errors, because it does not know some mixins/variables that are called.