### PR TITLE
Update JS include order - Fixes responsive accordion tabs

### DIFF
--- a/vendor/assets/js/foundation.js
+++ b/vendor/assets/js/foundation.js
@@ -20,7 +20,6 @@
 //= require foundation.magellan.js
 //= require foundation.offcanvas.js
 //= require foundation.orbit.js
-//= require foundation.responsiveAccordionTabs.js
 //= require foundation.responsiveMenu.js
 //= require foundation.responsiveToggle.js
 //= require foundation.reveal.js
@@ -29,3 +28,4 @@
 //= require foundation.tabs.js
 //= require foundation.toggler.js
 //= require foundation.tooltip.js
+//= require foundation.responsiveAccordionTabs.js


### PR DESCRIPTION
Responsive accordion tabs are currently broken due to a load order issue.

If you follow the guide on [responsive accordion tabs](https://foundation.zurb.com/sites/docs/responsive-accordion-tabs.html#accordion-html-markup) using this gem JS is throwing the following error;

```
Uncaught TypeError: Right-hand side of 'instanceof' is not an object
    at ResponsiveAccordionTabs._checkMediaQueries (foundation.responsiveAccordionTabs.self-e211e135a08bebf26a061b5d087b3a1269357f6e8af05d2a5f087aaae44e2fa2.js?body=1:305)
    at foundation.responsiveAccordionTabs.self-e211e135a08bebf26a061b5d087b3a1269357f6e8af05d2a5f087aaae44e2fa2.js?body=1:279
    at dispatch (jquery.self-bd7ddd393353a8d2480a622e80342adf488fb6006d667e8b42e4c0073393abee.js?body=1:5227)
    at elemData.handle (jquery.self-bd7ddd393353a8d2480a622e80342adf488fb6006d667e8b42e4c0073393abee.js?body=1:4879)
    at Object.trigger (jquery.self-bd7ddd393353a8d2480a622e80342adf488fb6006d667e8b42e4c0073393abee.js?body=1:5131)
    at jquery.self-bd7ddd393353a8d2480a622e80342adf488fb6006d667e8b42e4c0073393abee.js?body=1:5861
    at Function.each (jquery.self-bd7ddd393353a8d2480a622e80342adf488fb6006d667e8b42e4c0073393abee.js?body=1:371)
    at jQuery.fn.init.each (jquery.self-bd7ddd393353a8d2480a622e80342adf488fb6006d667e8b42e4c0073393abee.js?body=1:138)
    at jQuery.fn.init.trigger (jquery.self-bd7ddd393353a8d2480a622e80342adf488fb6006d667e8b42e4c0073393abee.js?body=1:5860)
    at foundation.util.mediaQuery.self-3492b7e03031b25b1025fd296476ac7c885b1a29e64ee8092fad06b3ff98a174.js?body=1:308
```

I've fixed this by updating the JS include order to be inline with [foundation-plugins.js](https://github.com/zurb/foundation-sites/blob/develop/js/entries/foundation-plugins.js)

@ncoden 