### PR TITLE
chore: add required dependencies for dummy tests app #259

### DIFF
--- a/foundation-rails.gemspec
+++ b/foundation-rails.gemspec
@@ -27,4 +27,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rails"
   spec.add_development_dependency "rspec", "~> 3.2"
+
+  # Required by dummy app
+  spec.add_development_dependency "bootsnap", "~> 1.3"
+  spec.add_development_dependency "listen", "~> 3.0"
 end


### PR DESCRIPTION
Some dependencies seems to be required by the dummy tests app. The `foundation-rails` generator fails to launch but errors are hidden by the shell call.

See:
* Logs for `bootstrap`: https://gist.github.com/ncoden/9837d62957423ec52b5b90f9047b6233
* Logs for `listen`: https://gist.github.com/ncoden/1aef4929f8453e41d17e06d412f6d5ec
* Similar issue: https://github.com/rmosolgo/graphql-ruby/issues/1425

Closes https://github.com/zurb/foundation-rails/issues/259
