### PR TITLE
docs: improve installation instructions #177

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,14 @@ If you're planning on using Sass, then you'll want to rename `application.css` t
 Append the following lines to your `app/assets/javascripts/application.js` file:
 
     //= require foundation
-    $(document).foundation();
+    $(function(){ $(document).foundation(); });
+
+Or if you use Turbolink:
+
+    //= require foundation
+    $(document).on('turbolinks:load', function() {
+        $(function(){ $(document).foundation(); });
+    });
 
 ### Set Viewport Width
 

--- a/README.md
+++ b/README.md
@@ -8,22 +8,30 @@
 
 Add these lines to your application's Gemfile:
 
-    $ gem 'foundation-rails'
-    $ gem 'autoprefixer-rails'
+```shell
+gem 'foundation-rails'
+gem 'autoprefixer-rails'
+```
 
 And then execute:
 
-    $ bundle
+```shell
+bundle
+```
 
 Or install it yourself as:
 
-    $ gem install foundation-rails
+```shell
+gem install foundation-rails
+```
 
 ### Configuring Foundation
 
 You can run the following command to add Foundation:
 
-    $ rails g foundation:install
+```shell
+rails g foundation:install
+```
 
 Generating Haml or Slim versions of the markup can be done by appending the `--haml` or `--slim` option to the above command.
 
@@ -31,9 +39,11 @@ Generating Haml or Slim versions of the markup can be done by appending the `--h
 
 [Motion UI](https://github.com/zurb/motion-ui) is a Sass library for creating flexible UI transitions and animations, and it comes packaged with the `foundation-rails` gem. To use Motion UI, uncomment the following lines from `foundation_and_overrides.scss`:
 
-    // @import 'motion-ui/motion-ui';
-    // @include motion-ui-transitions;
-    // @include motion-ui-animations;
+```scss
+// @import 'motion-ui/motion-ui';
+// @include motion-ui-transitions;
+// @include motion-ui-animations;
+```
 
 ## Manual Installation
 
@@ -41,47 +51,59 @@ Generating Haml or Slim versions of the markup can be done by appending the `--h
 
 Append the following line to your `app/assets/stylesheets/application.css` file:
 
-    /*= require foundation
+```scss
+/*= require foundation
+```
 
 If you're planning on using Sass, then you'll want to rename `application.css` to `application.scss`. That file should then look like:
 
-    @import "foundation_and_overrides";
-    /* Add imports of custom sass/scss files here */
+```scss
+@import "foundation_and_overrides";
+/* Add imports of custom sass/scss files here */
+```
 
 ### Add Foundation to your JS
 
 Append the following lines to your `app/assets/javascripts/application.js` file:
 
-    //= require foundation
+```js
+//= require foundation
+$(function(){ $(document).foundation(); });
+```
+
+Or if you use Turbolinks:
+
+```js
+//= require foundation
+$(document).on('turbolinks:load', function() {
     $(function(){ $(document).foundation(); });
-
-Or if you use Turbolink:
-
-    //= require foundation
-    $(document).on('turbolinks:load', function() {
-        $(function(){ $(document).foundation(); });
-    });
+});
+```
 
 ### Set Viewport Width
 
 Add the following line to the `head` of your page layout:
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+```
 
 ## Usage
 
 Run the generator to add foundation to the asset pipeline:
 
-    rails g foundation:install [layout_name] [options]
+```shell
+rails g foundation:install [layout_name] [options]
 
-    Options:
-      [--haml]  # Generate HAML layout instead of erb
-      [--slim]  # Generate Slim layout instead of erb
-    Runtime options:
-      -f, [--force]    # Overwrite files that already exist
-      -p, [--pretend]  # Run but do not make any changes
-      -q, [--quiet]    # Suppress status output
-      -s, [--skip]     # Skip files that already exist
+Options:
+    [--haml]         # Generate HAML layout instead of erb
+    [--slim]         # Generate Slim layout instead of erb
+Runtime options:
+    -f, [--force]    # Overwrite files that already exist
+    -p, [--pretend]  # Run but do not make any changes
+    -q, [--quiet]    # Suppress status output
+    -s, [--skip]     # Skip files that already exist
+```
 
 ## Contributing
 


### PR DESCRIPTION
### Changes
* Add installation example for Turbolink usage (#177, #201)
* Add markdown code syntax to examples and commands 

Closes #177 
Closes #201