### PR TITLE
🚀 Release v6.5.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    foundation-rails (6.4.3.0)
+    foundation-rails (6.5.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "foundation-rails",
-  "version": "6.4.3.0",
+  "version": "6.5.1.0",
   "dependencies": {
     "foundation-sites": "6.5.1",
     "motion-ui": "2.0.3"

--- a/gemfiles/rails_4.1.gemfile.lock
+++ b/gemfiles/rails_4.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    foundation-rails (6.4.3.0)
+    foundation-rails (6.5.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails_4.2.gemfile.lock
+++ b/gemfiles/rails_4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    foundation-rails (6.4.3.0)
+    foundation-rails (6.5.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails_5.0.gemfile.lock
+++ b/gemfiles/rails_5.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    foundation-rails (6.4.3.0)
+    foundation-rails (6.5.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails_5.1.gemfile.lock
+++ b/gemfiles/rails_5.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    foundation-rails (6.4.3.0)
+    foundation-rails (6.5.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails_5.2.gemfile.lock
+++ b/gemfiles/rails_5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    foundation-rails (6.4.3.0)
+    foundation-rails (6.5.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/foundation/rails/version.rb
+++ b/lib/foundation/rails/version.rb
@@ -1,5 +1,5 @@
 module Foundation
   module Rails
-    VERSION = "6.4.3.0"
+    VERSION = "6.5.1.0"
   end
 end


### PR DESCRIPTION
## foundation-rails v6.5.1.0 (2018-11-17)

This release update Foundation to v6.5.1 and 

### Changelog

* 🚚  <samp>#258</samp> - Provide multiple may to import JavaScript assets (@ncoden, #257)
* 🚨  <samp>#264</samp> - Add required dependencies for dummy tests app (@ncoden, #259)
* 🚨  <samp>#265</samp> - Run test across multiple rails versions (@ncoden, #256)
* 📖  <samp>#266</samp> - Improve installation instructions (@ncoden, #177)
* 📦  <samp>#270</samp> - Upgrade Foundation to v6.5.0 (@ncoden)
* 📦  <samp>#271</samp> - Upgrade Foundation to v6.5.1 (@ncoden)