### PR TITLE
Fix: Deprecation warning on sass 

### DIFF
--- a/vendor/assets/scss/util/_color.scss
+++ b/vendor/assets/scss/util/_color.scss
@@ -6,6 +6,15 @@
 
 $contrast-warnings: true !default;
 
+// Defaults
+$primary-color: null;
+$secondary-color: null;
+$success-color: null;
+$warning-color: null;
+$alert-color: null;
+$-zf-size: null;
+$-zf-bp-value: null;
+
 ////
 /// @group functions
 ////


### PR DESCRIPTION
# Summary

Fixes some deprecation warnings that have recently popped up.

```
13:12:13 rails.1   | DEPRECATION WARNING on line 115 of /usr/local/Cellar/tmuxinator/2.0.0/libexec/gems/foundation-rails-6.6.2.0/vendor/assets/scss/util/_color.scss:
13:12:13 rails.1   | !global assignments won't be able to declare new variables in future versions.
13:12:13 rails.1   | Consider adding `$primary-color: null` at the top level.
13:12:13 rails.1   |
13:12:13 rails.1   | DEPRECATION WARNING on line 120 of /usr/local/Cellar/tmuxinator/2.0.0/libexec/gems/foundation-rails-6.6.2.0/vendor/assets/scss/util/_color.scss:
13:12:13 rails.1   | !global assignments won't be able to declare new variables in future versions.
13:12:13 rails.1   | Consider adding `$secondary-color: null` at the top level.
13:12:13 rails.1   |
13:12:13 rails.1   | DEPRECATION WARNING on line 125 of /usr/local/Cellar/tmuxinator/2.0.0/libexec/gems/foundation-rails-6.6.2.0/vendor/assets/scss/util/_color.scss:
13:12:13 rails.1   | !global assignments won't be able to declare new variables in future versions.
13:12:13 rails.1   | Consider adding `$success-color: null` at the top level.
13:12:13 rails.1   |
13:12:13 rails.1   | DEPRECATION WARNING on line 130 of /usr/local/Cellar/tmuxinator/2.0.0/libexec/gems/foundation-rails-6.6.2.0/vendor/assets/scss/util/_color.scss:
13:12:13 rails.1   | !global assignments won't be able to declare new variables in future versions.
13:12:13 rails.1   | Consider adding `$warning-color: null` at the top level.
13:12:13 rails.1   |
13:12:13 rails.1   | DEPRECATION WARNING on line 135 of /usr/local/Cellar/tmuxinator/2.0.0/libexec/gems/foundation-rails-6.6.2.0/vendor/assets/scss/util/_color.scss:
13:12:13 rails.1   | !global assignments won't be able to declare new variables in future versions.
13:12:13 rails.1   | Consider adding `$alert-color: null` at the top level.
13:12:13 rails.1   |
13:12:13 rails.1   | DEPRECATION WARNING on line 164 of /usr/local/Cellar/tmuxinator/2.0.0/libexec/gems/foundation-rails-6.6.2.0/vendor/assets/scss/util/_breakpoint.scss:
13:12:13 rails.1   | !global assignments won't be able to declare new variables in future versions.
13:12:13 rails.1   | Consider adding `$-zf-size: null` at the top level.
13:12:13 rails.1   |
13:12:13 rails.1   | DEPRECATION WARNING on line 369 of /usr/local/Cellar/tmuxinator/2.0.0/libexec/gems/foundation-rails-6.6.2.0/vendor/assets/scss/util/_mixins.scss:
13:12:13 rails.1   | !global assignments won't be able to declare new variables in future versions.
13:12:13 rails.1   | Consider adding `$-zf-bp-value: null` at the top level.
13:12:13 rails.1   |
```