### PR TITLE
Change SassC dependency to Dart Sass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rails'
-gem 'sassc'
+gem 'sassc-embedded'
 gem 'railties'
 gem 'sprockets-es6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     foundation-rails (6.9.0.0)
       railties (>= 3.1.0)
-      sassc
+      sassc-embedded
       sprockets-es6
 
 GEM
@@ -119,6 +119,9 @@ GEM
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google-protobuf (4.28.2)
+      bigdecimal
+      rake (>= 13)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.7.0)
@@ -220,8 +223,11 @@ GEM
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
     ruby2_keywords (0.0.5)
-    sassc (2.4.0)
-      ffi (~> 1.9)
+    sass-embedded (1.79.4)
+      google-protobuf (~> 4.27)
+      rake (>= 13)
+    sassc-embedded (1.79.0)
+      sass-embedded (~> 1.79)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -256,7 +262,7 @@ DEPENDENCIES
   railties
   rake
   rspec
-  sassc
+  sassc-embedded
   sprockets-es6
 
 BUNDLED WITH

--- a/foundation-rails.gemspec
+++ b/foundation-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sassc"
+  spec.add_dependency "sassc-embedded"
   spec.add_dependency "railties", [">= 3.1.0"]
   spec.add_dependency "sprockets-es6"
 

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 7.1"
-gem "sassc"
+gem "sassc-embedded"
 gem "railties"
 gem "sprockets-es6"
 

--- a/gemfiles/rails_7.1.gemfile.lock
+++ b/gemfiles/rails_7.1.gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: ..
   specs:
-    foundation-rails (6.7.5.0)
+    foundation-rails (6.9.0.0)
       railties (>= 3.1.0)
-      sassc
+      sassc-embedded
       sprockets-es6
 
 GEM
@@ -218,8 +218,11 @@ GEM
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
     ruby2_keywords (0.0.5)
-    sassc (2.4.0)
-      ffi (~> 1.9)
+    sass-embedded (1.79.4)
+      google-protobuf (~> 4.27)
+      rake (>= 13)
+    sassc-embedded (1.79.0)
+      sass-embedded (~> 1.79)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -250,11 +253,11 @@ DEPENDENCIES
   capybara
   foundation-rails!
   listen
-  rails (~> 7.1)
+  rails
   railties
   rake
   rspec
-  sassc
+  sassc-embedded
   sprockets-es6
 
 BUNDLED WITH


### PR DESCRIPTION
Since SassC no longer supports the newer syntax used in foundation 6.8+, this pull request changes the dependency to Dart Sass.